### PR TITLE
#3: Use java6 to compile splitfile-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,15 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
 				<version>3.2</version>
 				<configuration>


### PR DESCRIPTION
This fixes #3 
